### PR TITLE
janitor-Allow workdir mounting in RStudio #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# General repository for running Rstudio or JupyterLab
+# General repository for running RStudio Server or JupyterLab
 
-This repository contains instructions for running an Rstudio server or for running a JupyterLab session on the CeMM cluster.
-
-The Rstudio directory also contains instructions for running Rstudio on the CCRI servers.
+This repository contains instructions for running an RStudio Server and for running a JupyterLab session on the CeMM cluster
+ and the CCRI clusters (RStudio Server only).

--- a/running_rstudio_singularity/.gitignore
+++ b/running_rstudio_singularity/.gitignore
@@ -1,0 +1,8 @@
+.cache
+.config
+.local
+logs
+R
+.Renviron
+.Rhistory
+.rstudio_server

--- a/running_rstudio_singularity/.gitignore
+++ b/running_rstudio_singularity/.gitignore
@@ -6,3 +6,4 @@ R
 .Renviron
 .Rhistory
 .rstudio_server
+.RData

--- a/running_rstudio_singularity/README.md
+++ b/running_rstudio_singularity/README.md
@@ -1,15 +1,16 @@
-# Running RStudio server images on clusters
+# Running RStudio Server images on clusters
 
-How to get an rstudio server running with singularity on CeMM's cluster, VBC's CLIP
- or our local machines (those where singularity has been installed -- Biohazard and
- the GPU)
+How to get an RStudio Server running with Apptainer/Singularity on the CeMM cluster or CCRI machines (those where Apptainer/Singularity
+ has been installed).
 
-Patricia provided us with a sample sbatch submission script file `rstudio-apptainer-interactive.sh`
- (ex. `rstudio-singularity-password.bash`) to get an rstudio server running on the
+## Rstudio server on CeMM's cluster
+
+Patricia provided us with a sample sbatch submission script file `run_rstudio_apptainer_cemm.sh`
+ (ex. `rstudio-singularity-password.bash`) to get an RStudio Server running on the
   CeMM cluster with singularity. Her email is included below:
 
 > Dear all,
-> 
+>
 >Per our last meeting, attached is a sample submission script for running rstudio
  server singularity jobs on the CeMM cluster.  Please replace the appropriate
   values: \<yourgroup\>, \<youruser\>, and the password.  Do not use your CeMM or
@@ -37,8 +38,6 @@ singularity pull --name rstudio-4.2.simg docker://rocker/rstudio:4.2
 >
 >Patricia
 
-## Rstudio server on CeMM's cluster
-
 Adapted Patricia's script to isolate different RStudio sessions based on the working
  directory of the session. The following changes were made:
 
@@ -50,24 +49,24 @@ Adapted Patricia's script to isolate different RStudio sessions based on the wor
 - In the `APPTAINER_BIND` variable, the path of the working directory on the CeMM
  cluster is bound to `/home/${USER}` in RStudio, instead of binding `/home` of
  the CeMM cluster to `/home` in RStudio
-- SSHing into the interactive node to set up port forwarding is no longer necessary - 
-  you can copy-paste the link in the log file directly into the browser from the CCRI 
+- SSHing into the interactive node to set up port forwarding is no longer necessary -
+  you can copy-paste the link in the log file directly into the browser from the CCRI
   or CeMM networks.
 
 ### Usage
 
-1. Copy the [`rstudio_apptainer_interactive.sh`](rstudio_apptainer_interactive.sh)
+1. Copy the [`run_rstudio_apptainer_cemm.sh`](run_rstudio_apptainer_cemm.sh)
   script to your project work directory
 2. Update the variables in the script to match your image name
-3. Run `sbatch rstudio_apptainer_interactive.sh`
-4. Look into the `rstudio_apptainer_interactive_<jobID>.log` file for the link: "`http://<hostname>.int.cemm.at:<port>`"
-  The hostname is the node the job is running on (e.g. d004) and the port is the network port (between 8000 and 9000 - these are available over the CCRI network). 
+3. Run `sbatch run_rstudio_apptainer_cemm.sh`
+4. Look into the `rstudio_apptainer_<jobID>.log` file for the link: "`http://<hostname>.int.cemm.at:<port>`"
+  The hostname is the node the job is running on (e.g. d004) and the port is the network port (between 8000 and 9000 - these are available over the CCRI network).
 5. Copy-paste the "`http://<hostname>.int.cemm.at:<port>`" link into your web browser (or cmd + click if using a Mac)
-6. Login with the username and password specified in the `rstudio_apptainer_interactive.sh` script (`APPTAINERENV_USER` and `APPTAINERENV_PASSWORD`)
+6. Login with the username and password specified in the `run_rstudio_apptainer_cemm.sh` script (`APPTAINERENV_USER` and `APPTAINERENV_PASSWORD`)
 
-### Available Rstudio server images
+### Available Rstudio Server images
 
-#### Prefered image
+#### Preferred image
 
 Rocker tidyverse 4.4 image, built by Aleks. Note: DESeq2 installs successfully with
  this: \
@@ -79,9 +78,9 @@ Singularity image of our docker image dockrstudio_4.2.0. Note: DESeq2 is not abl
  to be installed in the image due to `zlib.h` missing: \
 `/nobackup/lab_ccri_bicu/public/apptainer_images/ccribioinf_dockrstudio_4.2.0-v1.sif`\
 
-## Rstudio server on CCRI's machines
+## Rstudio Server on CCRI's machines
 
-Adapted Patricia's script to CCRI's machines (original file `rstudio-apptainer-interactive.sh` (ex.`rstudio-singularity-password.bash`), new file `run_singularity_rstudio_ccri.sh`).
+Adapted Patricia's script to CCRI's machines to create `run_singularity_rstudio_ccri.sh`.
  The following changes were made:
 
 - Removed sbatch commands
@@ -93,14 +92,12 @@ Adapted Patricia's script to CCRI's machines (original file `rstudio-apptainer-i
 
 ### Usage
 
-1. Update the variables in the script to match your image name, R version and working
-2.  directory
-3. Start a tmux session
-4. Run `bash run_singularity_rstudio_ccri.sh`
-5. In a web browser go to the `machineIPaddress:port`, which will be printed to
-6.  screen after starting the script
+1. Update the variables in the script to match your image name, R version and working directory
+2. Start a tmux session
+3. Run `bash run_singularity_rstudio_ccri.sh`
+4. In a web browser go to the `machineIPaddress:port`, which will be printed to screen after starting the script
 
-### Rstudio server singularity images available:
+### Rstudio server singularity images available
 
  `~/bioinf_isilon/core_bioinformatics_unit/Public/singularity_images/ccribioinf_dockrstudio_4.2.0-v1.sif`
   `~/bioinf_isilon/core_bioinformatics_unit/Public/singularity_images/wouter_m_dockrstudio_v4.3.2-V1.simg`

--- a/running_rstudio_singularity/README.md
+++ b/running_rstudio_singularity/README.md
@@ -64,6 +64,11 @@ Adapted Patricia's script to isolate different RStudio sessions based on the wor
 5. Copy-paste the "`http://<hostname>.int.cemm.at:<port>`" link into your web browser (or cmd + click if using a Mac)
 6. Login with the username and password specified in the `run_rstudio_apptainer_cemm.sh` script (`APPTAINERENV_USER` and `APPTAINERENV_PASSWORD`)
 
+#### Automatically loaded custom functions
+
+You can use `~/.Ractivate.R` to automatically load custom functions into RStudio Server at startup. An example `save_session()`
+ function allows you to save both Rhistory (into `~/.Rhistory`) and RData (into `~/.RData`) with a single command.
+
 ### Available Rstudio Server images
 
 #### Preferred image

--- a/running_rstudio_singularity/README.md
+++ b/running_rstudio_singularity/README.md
@@ -3,6 +3,8 @@
 How to get an RStudio Server running with Apptainer/Singularity on the CeMM cluster or CCRI machines (those where Apptainer/Singularity
  has been installed).
 
+You can use the included [`.gitignore`](.gitignore) to exclude RStudio Server files you likely do not want to track with `git`.
+
 ## Rstudio server on CeMM's cluster
 
 Patricia provided us with a sample sbatch submission script file `run_rstudio_apptainer_cemm.sh`

--- a/running_rstudio_singularity/run_rstudio_apptainer_cemm.sh
+++ b/running_rstudio_singularity/run_rstudio_apptainer_cemm.sh
@@ -37,19 +37,19 @@ mkdir -p -m 700 "${rstudio_server_config_dir}/run" "${rstudio_server_config_dir}
 # R Session Configuration File https://docs.posit.co/ide/server-pro/reference/rsession_conf.html
 cat >"${rstudio_server_config_dir}/rsession.conf" <<END
 # Set R_LIBS_USER to a path specific to rocker/rstudio to avoid conflicts with personal libraries from any R installation in the host environment
-r-libs-user=R/${r_version}
+r-libs-user=${rstudio_server_config_dir}/R/${r_version}
 # Prevent R session from timeout
 session-timeout-minutes=0
 END
 
 # .Rprofile and default functions
 cat >"${rstudio_server_config_dir}/.Rprofile" <<END
-source(".rstudio_server/.Ractivate.R")
+source("${rstudio_server_config_dir}/.Ractivate.R")
 END
 
 # Location or .Rprofile - project-wide
 cat >".Renviron" <<END
-R_PROFILE_USER=".rstudio_server/.Rprofile"
+R_PROFILE_USER="${rstudio_server_config_dir}/.Rprofile"
 END
 
 # Functions to load at startup
@@ -64,7 +64,7 @@ END
 export APPTAINER_BIND="${rstudio_server_config_dir}/run:/run,${rstudio_server_config_dir}/tmp:/tmp,\
 ${rstudio_server_config_dir}/rsession.conf:/etc/rstudio/rsession.conf,${rstudio_server_config_dir}/var/lib/rstudio-server:/var/lib/rstudio-server,\
 ${rstudio_server_config_dir}/run:/var/run,\
-$(pwd):/home/${USER},${rstudio_server_config_dir}:/home/${USER}/.rstudio_server,\
+$(pwd):/home/${USER},${rstudio_server_config_dir}:${rstudio_server_config_dir},\
 /nobackup:/nobackup,/research:/research"
 
 # Do not suspend idle sessions


### PR DESCRIPTION
- Updates the RStudio Server script for the CeMM cluster to mount the current working directory to RStudio as the main directory so we can easily browse it through the RStudio Server GUI

closes #11 